### PR TITLE
make partial serializers configurable from outside

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - EMBER_TRY_SCENARIO=2.4
   - EMBER_TRY_SCENARIO=2.5
   - EMBER_TRY_SCENARIO=2.6
+  - EMBER_TRY_SCENARIO=2.7
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
@@ -28,14 +29,15 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g bower
+  - npm install phantomjs-prebuilt
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# ember-data-partial-model Changelog
+
+## master
+
+Update notes:
+
+  - None
+
+Changes:
+  - [FEATURE] #27 make partial serializers configurable from outside by @Azdaroth

--- a/README.md
+++ b/README.md
@@ -127,6 +127,52 @@ export default Mixin.create(baseSerializerMixin, {
 });
 ```
 
+## Extending partial serializers
+You can provide extensions and list of mixins to be applied for partial serializers. If you defined `extended` partial in `user` model like this:
+
+``` js
+// app/models/user.js
+
+import { PartialModel, partial } from 'ember-data-partial-model/utils/model';
+const { attr } = DS;
+
+export default PartialModel.extend({
+  name: attr(),
+  extended: partial('user', 'extended', {
+    twitter: attr(),
+    clients: hasMany('client', { async: false })
+  })
+});
+```
+
+add you want to make `clients` relationship embedded and serialize all `clients` records when serializing `user` model, you could customize `user` serializer the following way:
+
+``` js
+// app/serializers/user.js
+
+import Ember from 'ember';
+import DS from 'ember-data';
+import ApplicationSerializer from './application';
+
+const { EmbeddedRecordsMixin } = DS;
+const { Mixin } = Ember;
+
+export default ApplicationSerializer.extend({
+  partialSerializersExtensions: {
+    extended: {
+      attrs: {
+        clients: { embedded: 'always' }
+      }
+    }
+  },
+
+  partialSerializersMixins: {
+    extended: [EmbeddedRecordsMixin]
+  }
+});
+```
+
+All extensions defined inside `partialSerializersExtensions` will be copied for given partial and all mixins  defined in `partialSerializersMixins` will be used when defining partial serializer.
 
 ## Installation
 

--- a/addon/mixins/store.js
+++ b/addon/mixins/store.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-const { Mixin } = Ember;
+const { Mixin, merge } = Ember;
 const { Model } = DS;
 
 export default Mixin.create({
@@ -101,8 +101,8 @@ export default Mixin.create({
     let serializerOverrides = {};
     let externalOverrides = parentSerializer.partialSerializersExtensions &&
       parentSerializer.partialSerializersExtensions[partialName] || {};
-    Object.assign(serializerOverrides, externalOverrides);
-    Object.assign(serializerOverrides, {
+    merge(serializerOverrides, externalOverrides);
+    merge(serializerOverrides, {
       modelNameFromPayloadKey() {
         return this._super(partialExtensionSerializerName);
       }

--- a/app/serializers/user.js
+++ b/app/serializers/user.js
@@ -1,5 +1,0 @@
-import DS from 'ember-data';
-import PartialModelRESTSerializer from 'ember-data-partial-model/mixins/rest-serializer';
-import RESTSerializer from 'ember-data/serializers/rest';
-
-export default RESTSerializer.extend(PartialModelRESTSerializer);

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -57,6 +57,14 @@ module.exports = {
       }
     },
     {
+      name: '2.7',
+       dependencies: {
+        'ember': '2.7.0',
+        'ember-data': '2.7.0',
+        "ember-cli-shims": "0.1.0",
+      }
+    },
+    {
       name: 'default',
       dependencies: {
 

--- a/tests/dummy/app/mirage/factories/client.js
+++ b/tests/dummy/app/mirage/factories/client.js
@@ -1,7 +1,5 @@
 import Mirage from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
-  name: i => `User ${i}`,
-  twitter: i => `@user-${i}`,
-  clients: []
+  fullName: i => `Awesome Client ${i}`
 });

--- a/tests/dummy/app/mirage/fixtures/user_extendeds.js
+++ b/tests/dummy/app/mirage/fixtures/user_extendeds.js
@@ -1,9 +1,58 @@
 export default [
-  {id: 1, name: 'joliss', twitter: "joliss"},
-  {id: 2, name: 'igort', twitter: "terzicigor"},
-  {id: 3, name: 'tchak', twitter: "tchak13"},
-  {id: 4, name: 'wecc', twitter: "ChristofferP"},
-  {id: 5, name: 'bmac', twitter: "BezoMaxo"},
-  {id: 6, name: 'teddyzeenny', twitter: "teddyzeenny"},
-  {id: 7, name: 'zencocoon', twitter: "sebgrosjean"}
+  {
+    id: 1,
+    name: 'joliss',
+    twitter: "joliss",
+    clients: [
+
+    ]
+  },
+  {
+    id: 2,
+    name: 'igort',
+    twitter: "terzicigor",
+    clients: [
+
+    ]
+  },
+  {
+    id: 3,
+    name: 'tchak',
+    twitter: "tchak13",
+    clients: [
+
+    ]
+  },
+  {
+    id: 4,
+    name: 'wecc',
+    twitter: "ChristofferP",
+    clients: [
+
+    ]
+  },
+  {
+    id: 5,
+    name: 'bmac',
+    twitter: "BezoMaxo",
+    clients: [
+
+    ]
+  },
+  {
+    id: 6,
+    name: 'teddyzeenny',
+    twitter: "teddyzeenny",
+    clients: [
+
+    ]
+  },
+  {
+    id: 7,
+    name: 'zencocoon',
+    twitter: "sebgrosjean",
+    clients: [
+
+    ]
+  }
 ];

--- a/tests/dummy/app/models/client.js
+++ b/tests/dummy/app/models/client.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+const { Model, attr, belongsTo } = DS;
+
+export default Model.extend({
+  fullName: attr()
+});

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,9 +1,10 @@
 import { PartialModel, partial } from 'ember-data-partial-model/utils/model';
-const { attr } = DS;
+const { attr, hasMany } = DS;
 
 export default PartialModel.extend({
   name: attr(),
   extended: partial('user', 'extended', {
-    twitter: attr()
+    twitter: attr(),
+    clients: hasMany('client', { async: false })
   })
 });

--- a/tests/dummy/app/serializers/client.js
+++ b/tests/dummy/app/serializers/client.js
@@ -1,0 +1,3 @@
+import RESTSerializer from 'ember-data/serializers/rest';
+
+export default RESTSerializer.extend({});

--- a/tests/dummy/app/serializers/user.js
+++ b/tests/dummy/app/serializers/user.js
@@ -1,13 +1,21 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 import PartialModelRESTSerializer from 'ember-data-partial-model/mixins/rest-serializer';
 import RESTSerializer from 'ember-data/serializers/rest';
 
+const { EmbeddedRecordsMixin } = DS;
+const { Mixin } = Ember;
+
 export default RESTSerializer.extend(PartialModelRESTSerializer, {
-  partialAttrs: {
-    'extended': {
-      clients: { embedded: 'always' }
+  partialSerializersExtensions: {
+    extended: {
+      attrs: {
+        clients: { embedded: 'always' }
+      }
     }
   },
 
-  includeEmbeddedRecordMixinInPartials: ['extended']
+  partialSerializersMixins: {
+    extended: [EmbeddedRecordsMixin, Mixin.create({ __magicAttributeForTest__: true })]
+  }
 });

--- a/tests/dummy/app/serializers/user.js
+++ b/tests/dummy/app/serializers/user.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+import PartialModelRESTSerializer from 'ember-data-partial-model/mixins/rest-serializer';
+import RESTSerializer from 'ember-data/serializers/rest';
+
+export default RESTSerializer.extend(PartialModelRESTSerializer, {
+  partialAttrs: {
+    'extended': {
+      clients: { embedded: 'always' }
+    }
+  },
+
+  includeEmbeddedRecordMixinInPartials: ['extended']
+});

--- a/tests/unit/jsonapi-serializer-test.js
+++ b/tests/unit/jsonapi-serializer-test.js
@@ -60,7 +60,7 @@ test('normalize for partial model assigns id from main model to extended models'
 });
 
 test('serialize performs serialization by merging payload from partial models to payload from main model and deletes partial models from hash', function(assert) {
-  var user;
+  let user;
   Ember.run(() => {
     user = store.createRecord('user', { name: 'zencocoon', twitter: 'sebgrosjean' });
   });

--- a/tests/unit/rest-serializer-test.js
+++ b/tests/unit/rest-serializer-test.js
@@ -46,11 +46,25 @@ test('normalize for partial model assigns id from main model to extended models'
 });
 
 test('serialize performs serialization by merging payload from partial models to payload from main model and deletes partial models from hash', function(assert) {
-  var user;
+  var user, client;
   Ember.run(() => {
+    client = store.createRecord('client', { fullName: 'Awesome Client', id: 1 });
     user = store.createRecord('user', { name: 'zencocoon', twitter: 'sebgrosjean' });
+    user.get('clients').pushObject(client);
   });
 
-  let serializedUser = { name: 'zencocoon', twitter: 'sebgrosjean' };
+
+  let serializedUser = {
+    name: 'zencocoon',
+    twitter: 'sebgrosjean',
+    clients: [
+      {
+        fullName: 'Awesome Client',
+        id: '1'
+      }
+    ]
+  };
   assert.deepEqual(serializer.serialize(user._createSnapshot(), {}), serializedUser);
 });
+
+

--- a/tests/unit/rest-serializer-test.js
+++ b/tests/unit/rest-serializer-test.js
@@ -45,14 +45,15 @@ test('normalize for partial model assigns id from main model to extended models'
   assert.deepEqual(serializer.normalize(store.modelFor('user'), payload), normalizedPayload);
 });
 
-test('serialize performs serialization by merging payload from partial models to payload from main model and deletes partial models from hash', function(assert) {
-  var user, client;
+test('serialize performs serialization by merging payload from partial models ' +
+  'to payload from main model and deletes partial models from hash ' +
+  'and respects extensions for partial serializer', function(assert) {
+  let user, client;
   Ember.run(() => {
     client = store.createRecord('client', { fullName: 'Awesome Client', id: 1 });
     user = store.createRecord('user', { name: 'zencocoon', twitter: 'sebgrosjean' });
     user.get('clients').pushObject(client);
   });
-
 
   let serializedUser = {
     name: 'zencocoon',

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -28,7 +28,7 @@ test('modelFor generates partial extension model with name reference to parent m
 });
 
 
-test('modelFor generates serializer for partial extension model', function(assert) {
+test('modelFor generates serializer for partial extension model respecting mixins and overrides', function(assert) {
   assert.equal(app.__container__.lookup('serializer:user-extended'), null);
 
   // will generate user-extended serializer
@@ -36,6 +36,8 @@ test('modelFor generates serializer for partial extension model', function(asser
 
   let serializer = store.serializerFor('user-extended');
   assert.equal(serializer.modelNameFromPayloadKey(), 'user-extended');
+  assert.deepEqual(serializer.attrs, { clients: { embedded: 'always' } });
+  assert.equal(serializer.__magicAttributeForTest__, true);
 });
 
 

--- a/tests/unit/utils/model-test.js
+++ b/tests/unit/utils/model-test.js
@@ -36,7 +36,7 @@ test('PartialModel has reflections on partialDescriptors', function(assert) {
   assert.equal(partialDescriptorForExtended.type, 'user-extended');
   assert.equal(partialDescriptorForExtended.isRelationship, true);
   assert.equal(partialDescriptorForExtended.kind, 'belongsTo');
-  assert.deepEqual(Object.keys(partialDescriptorForExtended.options.classHash), ['twitter']);
+  assert.deepEqual(Object.keys(partialDescriptorForExtended.options.classHash), ['twitter', 'clients']);
 });
 
 test('PartialModel has defined aliases for setting / gettings properties in partials', function(assert) {
@@ -95,4 +95,3 @@ test('properties from partial models are always loaded before save', function(as
     assert.equal(JSON.parse(updateRequest.requestBody).user.twitter, 'sebgrosjean');
   });
 });
-


### PR DESCRIPTION
Still work in progress, there are some things that needs rethinking (and tests of course :P).

This PR adds support for serializing associations, including proper handling of embedded ones.

We need to add some extra API on serializer-level which will decide how the attributes from partials are supposed to be serialised and what kind of mixins can we apply to partial serialiser , here is current example:

``` js
// app/serializers/user.js
import DS from 'ember-data';
import PartialModelRESTSerializer from 'ember-data-partial-model/mixins/rest-serializer';
import RESTSerializer from 'ember-data/serializers/rest';

export default RESTSerializer.extend(PartialModelRESTSerializer, {
  partialAttrs: {
    'extended': {
      clients: { embedded: 'always' }
    }
  },

  includeEmbeddedRecordMixinInPartials: ['extended']
});
```

`partialAttrs` is kind of ok, but I don't really like `includeEmbeddedRecordMixinInPartials`, it's coupled to only one mixin. This might be ok for most cases, but we will have a problem when we need some extra mixins, maybe it should be an array of mixins for given partial serialiser, like:

``` js
partialMixins: {
  'extended': [DS.EmbeddedRecordsMixin, WhateverItTakesMixin, EmberFTWMixin]
}
```

Will get back to it hopefully tomorrow and finish it.
